### PR TITLE
feat(backend): /api/metrics Prometheus endpoint + sync instrumentation

### DIFF
--- a/backend/src/data/documents.ts
+++ b/backend/src/data/documents.ts
@@ -1,4 +1,8 @@
 import type { Storage } from "../db/engine.ts";
+import { metrics } from "../metrics.ts";
+
+const observeDb = (op: string, start: number): void =>
+	metrics.dbDuration.observe((performance.now() - start) / 1000, { op });
 
 export type IncomingDoc = {
 	id: string;
@@ -41,12 +45,17 @@ export async function getManifest(
 	storage: Storage,
 	vaultId: string,
 ): Promise<ManifestEntry[]> {
-	return await storage.withRead((conn) =>
-		conn.query<ManifestEntry>(
-			"SELECT id, updated_at FROM documents WHERE vault_id = ?",
-			vaultId,
-		),
-	);
+	const start = performance.now();
+	try {
+		return await storage.withRead((conn) =>
+			conn.query<ManifestEntry>(
+				"SELECT id, updated_at FROM documents WHERE vault_id = ?",
+				vaultId,
+			),
+		);
+	} finally {
+		observeDb("manifest", start);
+	}
 }
 
 export async function getDocs(
@@ -55,15 +64,20 @@ export async function getDocs(
 	ids: string[],
 ): Promise<DocRecord[]> {
 	if (ids.length === 0) return [];
-	return await storage.withRead(async (conn) => {
-		const placeholders = ids.map(() => "?").join(",");
-		const rows = await conn.query<DocRow>(
-			`SELECT id, updated_at, deleted_at, data FROM documents WHERE vault_id = ? AND id IN (${placeholders})`,
-			vaultId,
-			...ids,
-		);
-		return rows.map(toRecord);
-	});
+	const start = performance.now();
+	try {
+		return await storage.withRead(async (conn) => {
+			const placeholders = ids.map(() => "?").join(",");
+			const rows = await conn.query<DocRow>(
+				`SELECT id, updated_at, deleted_at, data FROM documents WHERE vault_id = ? AND id IN (${placeholders})`,
+				vaultId,
+				...ids,
+			);
+			return rows.map(toRecord);
+		});
+	} finally {
+		observeDb("fetch", start);
+	}
 }
 
 export async function bulkUpsert(
@@ -72,35 +86,40 @@ export async function bulkUpsert(
 	docs: IncomingDoc[],
 ): Promise<UpsertResult[]> {
 	if (docs.length === 0) return [];
-	return await storage.withConn((conn) =>
-		conn.transaction(async (tx) => {
-			const results: UpsertResult[] = [];
-			for (const incoming of docs) {
-				const stored = await tx.get<{ updated_at: string }>(
-					"SELECT updated_at FROM documents WHERE vault_id = ? AND id = ?",
-					vaultId,
-					incoming.id,
-				);
-				if (stored && stored.updated_at > incoming.updated_at) {
-					results.push({
-						id: incoming.id,
-						status: "stale",
-						current_updated_at: stored.updated_at,
-					});
-					continue;
-				}
-				await tx.run(
-					`INSERT INTO documents (vault_id, id, updated_at, deleted_at, data) VALUES (?, ?, ?, ?, ?)
+	const start = performance.now();
+	try {
+		return await storage.withConn((conn) =>
+			conn.transaction(async (tx) => {
+				const results: UpsertResult[] = [];
+				for (const incoming of docs) {
+					const stored = await tx.get<{ updated_at: string }>(
+						"SELECT updated_at FROM documents WHERE vault_id = ? AND id = ?",
+						vaultId,
+						incoming.id,
+					);
+					if (stored && stored.updated_at > incoming.updated_at) {
+						results.push({
+							id: incoming.id,
+							status: "stale",
+							current_updated_at: stored.updated_at,
+						});
+						continue;
+					}
+					await tx.run(
+						`INSERT INTO documents (vault_id, id, updated_at, deleted_at, data) VALUES (?, ?, ?, ?, ?)
 					 ON CONFLICT(vault_id, id) DO UPDATE SET updated_at = excluded.updated_at, deleted_at = excluded.deleted_at, data = excluded.data`,
-					vaultId,
-					incoming.id,
-					incoming.updated_at,
-					incoming.deleted_at,
-					incoming.data,
-				);
-				results.push({ id: incoming.id, status: "accepted" });
-			}
-			return results;
-		}),
-	);
+						vaultId,
+						incoming.id,
+						incoming.updated_at,
+						incoming.deleted_at,
+						incoming.data,
+					);
+					results.push({ id: incoming.id, status: "accepted" });
+				}
+				return results;
+			}),
+		);
+	} finally {
+		observeDb("push", start);
+	}
 }

--- a/backend/src/metrics.ts
+++ b/backend/src/metrics.ts
@@ -1,0 +1,189 @@
+type Labels = Record<string, string>;
+
+const labelKey = (labels: Labels): string =>
+	Object.keys(labels)
+		.sort()
+		.map((k) => `${k}=${labels[k]}`)
+		.join(",");
+
+const escapeLabelValue = (value: string): string =>
+	value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n");
+
+const renderLabels = (labels: Labels): string => {
+	const keys = Object.keys(labels).sort();
+	if (keys.length === 0) return "";
+	return `{${keys.map((k) => `${k}="${escapeLabelValue(labels[k])}"`).join(",")}}`;
+};
+
+const splitKey = (key: string): Labels => {
+	const labels: Labels = {};
+	if (key.length === 0) return labels;
+	for (const pair of key.split(",")) {
+		const eq = pair.indexOf("=");
+		labels[pair.slice(0, eq)] = pair.slice(eq + 1);
+	}
+	return labels;
+};
+
+class Counter {
+	private values = new Map<string, number>();
+	constructor(
+		readonly name: string,
+		readonly help: string,
+	) {}
+
+	inc(labels: Labels = {}, by = 1): void {
+		const k = labelKey(labels);
+		this.values.set(k, (this.values.get(k) ?? 0) + by);
+	}
+
+	render(): string {
+		const lines = [
+			`# HELP ${this.name} ${this.help}`,
+			`# TYPE ${this.name} counter`,
+		];
+		for (const [k, v] of this.values) {
+			lines.push(`${this.name}${renderLabels(splitKey(k))} ${v}`);
+		}
+		return lines.join("\n");
+	}
+}
+
+class Gauge {
+	private values = new Map<string, number>();
+	constructor(
+		readonly name: string,
+		readonly help: string,
+	) {}
+
+	inc(labels: Labels = {}, by = 1): void {
+		const k = labelKey(labels);
+		this.values.set(k, (this.values.get(k) ?? 0) + by);
+	}
+
+	dec(labels: Labels = {}, by = 1): void {
+		this.inc(labels, -by);
+	}
+
+	set(value: number, labels: Labels = {}): void {
+		this.values.set(labelKey(labels), value);
+	}
+
+	render(): string {
+		const lines = [
+			`# HELP ${this.name} ${this.help}`,
+			`# TYPE ${this.name} gauge`,
+		];
+		for (const [k, v] of this.values) {
+			lines.push(`${this.name}${renderLabels(splitKey(k))} ${v}`);
+		}
+		return lines.join("\n");
+	}
+}
+
+const DEFAULT_BUCKETS = [
+	0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5,
+];
+
+// Sub-millisecond resolution for in-process DB ops (50us .. 100ms).
+const FINE_BUCKETS = [
+	0.00005, 0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05,
+	0.1,
+];
+
+class Histogram {
+	private buckets: Map<string, number[]> = new Map();
+	private sums = new Map<string, number>();
+	private counts = new Map<string, number>();
+	constructor(
+		readonly name: string,
+		readonly help: string,
+		readonly bounds: number[] = DEFAULT_BUCKETS,
+	) {}
+
+	observe(seconds: number, labels: Labels = {}): void {
+		const k = labelKey(labels);
+		let counts = this.buckets.get(k);
+		if (!counts) {
+			counts = new Array(this.bounds.length).fill(0);
+			this.buckets.set(k, counts);
+		}
+		for (let i = 0; i < this.bounds.length; i++) {
+			if (seconds <= this.bounds[i]) counts[i] += 1;
+		}
+		this.sums.set(k, (this.sums.get(k) ?? 0) + seconds);
+		this.counts.set(k, (this.counts.get(k) ?? 0) + 1);
+	}
+
+	render(): string {
+		const lines = [
+			`# HELP ${this.name} ${this.help}`,
+			`# TYPE ${this.name} histogram`,
+		];
+		for (const [k, counts] of this.buckets) {
+			const labels = splitKey(k);
+			for (let i = 0; i < this.bounds.length; i++) {
+				lines.push(
+					`${this.name}_bucket${renderLabels({ ...labels, le: String(this.bounds[i]) })} ${counts[i]}`,
+				);
+			}
+			const total = this.counts.get(k) ?? 0;
+			lines.push(
+				`${this.name}_bucket${renderLabels({ ...labels, le: "+Inf" })} ${total}`,
+			);
+			lines.push(
+				`${this.name}_sum${renderLabels(labels)} ${this.sums.get(k) ?? 0}`,
+			);
+			lines.push(`${this.name}_count${renderLabels(labels)} ${total}`);
+		}
+		return lines.join("\n");
+	}
+}
+
+export const metrics = {
+	wsConnections: new Gauge(
+		"moneeey_ws_connections",
+		"Active vault websocket connections",
+	),
+	wsMessages: new Counter(
+		"moneeey_ws_messages_total",
+		"Inbound websocket messages by type",
+	),
+	syncPushDocs: new Counter(
+		"moneeey_sync_push_docs_total",
+		"Documents accepted via push",
+	),
+	pushDuration: new Histogram(
+		"moneeey_sync_push_duration_seconds",
+		"push handler duration",
+	),
+	fetchDuration: new Histogram(
+		"moneeey_sync_fetch_duration_seconds",
+		"fetch handler duration",
+	),
+	manifestDuration: new Histogram(
+		"moneeey_sync_manifest_duration_seconds",
+		"manifest handler duration",
+	),
+	dbDuration: new Histogram(
+		"moneeey_db_op_duration_seconds",
+		"data-layer DB operation duration by op",
+		FINE_BUCKETS,
+	),
+	errors: new Counter("moneeey_errors_total", "Errors by area"),
+};
+
+const registry = [
+	metrics.wsConnections,
+	metrics.wsMessages,
+	metrics.syncPushDocs,
+	metrics.pushDuration,
+	metrics.fetchDuration,
+	metrics.manifestDuration,
+	metrics.dbDuration,
+	metrics.errors,
+];
+
+export function renderMetrics(): string {
+	return `${registry.map((m) => m.render()).join("\n\n")}\n`;
+}

--- a/backend/src/metrics_test.ts
+++ b/backend/src/metrics_test.ts
@@ -1,0 +1,27 @@
+import { metrics, renderMetrics } from "./metrics.ts";
+import { assert } from "./test.ts";
+
+Deno.test(function countersGaugesHistogramsRender() {
+	metrics.wsMessages.inc({ type: "push" });
+	metrics.wsMessages.inc({ type: "push" });
+	metrics.wsConnections.set(7);
+	metrics.dbDuration.observe(0.003, { op: "push" });
+
+	const out = renderMetrics();
+	const has = (needle: string) =>
+		assert.assertEquals(out.includes(needle), true);
+
+	has("# TYPE moneeey_ws_messages_total counter");
+	has('moneeey_ws_messages_total{type="push"} 2');
+	has("# TYPE moneeey_ws_connections gauge");
+	has("moneeey_ws_connections 7");
+	has("# TYPE moneeey_db_op_duration_seconds histogram");
+	has('moneeey_db_op_duration_seconds_count{op="push"} 1');
+	has('moneeey_db_op_duration_seconds_bucket{le="+Inf",op="push"} 1');
+});
+
+Deno.test(function labelValuesAreEscaped() {
+	metrics.wsMessages.inc({ type: 'a"b\\c' });
+	const out = renderMetrics();
+	assert.assertEquals(out.includes('type="a\\"b\\\\c"'), true);
+});

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -4,6 +4,7 @@ import { getStorage } from "./data/storage_singleton.ts";
 import { oak } from "./deps.ts";
 import { purgeStaleTestUsers } from "./janitor.ts";
 import { Logger } from "./logger.ts";
+import { renderMetrics } from "./metrics.ts";
 import { setupVaultSync } from "./sync/vault.ts";
 
 async function ensureMetaInitialized() {
@@ -29,6 +30,10 @@ export function createServer() {
 	});
 	router.get("/api", ({ response }) => {
 		response.body = JSON.stringify({ hello: "Welcome to Moneeey API" });
+	});
+	router.get("/api/metrics", ({ response }) => {
+		response.headers.set("content-type", "text/plain; version=0.0.4");
+		response.body = renderMetrics();
 	});
 
 	setupAuth(app, router);

--- a/backend/src/sync/protocol.ts
+++ b/backend/src/sync/protocol.ts
@@ -10,6 +10,7 @@ import { userHasAccess } from "../data/vaults.ts";
 import type { Storage } from "../db/engine.ts";
 import { authJwt, sessionJwt } from "../jwt.ts";
 import { Logger } from "../logger.ts";
+import { metrics } from "../metrics.ts";
 import type { PeerSink, VaultHub } from "./hub.ts";
 
 const logger = Logger("sync/protocol");
@@ -18,6 +19,14 @@ const MAX_MANIFEST_ENTRIES = 50_000;
 const MAX_FETCH_IDS = 100;
 const MAX_PUSH_DOCS = 100;
 const MAX_DATA_BYTES = 256 * 1024;
+
+const KNOWN_MESSAGE_TYPES = new Set([
+	"hello",
+	"manifest",
+	"fetch",
+	"push",
+	"ping",
+]);
 
 export const CLOSE_UNAUTHORIZED = 4401;
 export const CLOSE_FORBIDDEN = 4403;
@@ -162,15 +171,24 @@ class ReadyHandler implements MessageHandler {
 			case "ping":
 				this.ctx.peer.send({ type: "pong" });
 				return this;
-			case "manifest":
+			case "manifest": {
+				const t = performance.now();
 				await this.handleManifest(msg as ManifestMsg);
+				metrics.manifestDuration.observe((performance.now() - t) / 1000);
 				return this;
-			case "fetch":
+			}
+			case "fetch": {
+				const t = performance.now();
 				await this.handleFetch(msg as FetchMsg);
+				metrics.fetchDuration.observe((performance.now() - t) / 1000);
 				return this;
-			case "push":
+			}
+			case "push": {
+				const t = performance.now();
 				await this.handlePush(msg as PushMsg);
+				metrics.pushDuration.observe((performance.now() - t) / 1000);
 				return this;
+			}
 			default:
 				sendError(
 					this.ctx.peer,
@@ -320,6 +338,7 @@ class ReadyHandler implements MessageHandler {
 		const acceptedIds = new Set(
 			results.filter((r) => r.status === "accepted").map((r) => r.id),
 		);
+		metrics.syncPushDocs.inc({}, acceptedIds.size);
 		if (acceptedIds.size === 0) return;
 		const broadcastDocs: DocRecord[] = incoming
 			.filter((d) => acceptedIds.has(d.id))
@@ -354,9 +373,15 @@ export class VaultProtocol {
 			sendError(this.ctx.peer, undefined, "bad_request", "invalid JSON");
 			return;
 		}
+		const type =
+			typeof msg.type === "string" && KNOWN_MESSAGE_TYPES.has(msg.type)
+				? msg.type
+				: "other";
+		metrics.wsMessages.inc({ type });
 		try {
 			this.handler = await this.handler.handle(msg);
 		} catch (err) {
+			metrics.errors.inc({ area: "protocol" });
 			logger.error("handler error", { err, type: msg.type });
 			const requestId = (msg as { request_id?: string }).request_id;
 			sendError(

--- a/backend/src/sync/vault.ts
+++ b/backend/src/sync/vault.ts
@@ -1,6 +1,7 @@
 import { getStorage } from "../data/storage_singleton.ts";
 import { oak } from "../deps.ts";
 import { Logger } from "../logger.ts";
+import { metrics } from "../metrics.ts";
 import { type PeerSink, VaultHub } from "./hub.ts";
 import { VaultProtocol } from "./protocol.ts";
 
@@ -33,13 +34,21 @@ export function setupVaultSync(router: oak.Router) {
 			},
 		};
 		const protocol = new VaultProtocol(getStorage(), hub, peer);
+		metrics.wsConnections.inc();
+		let closed = false;
+		const onClosed = () => {
+			if (closed) return;
+			closed = true;
+			metrics.wsConnections.dec();
+			protocol.handleClose();
+		};
 		ws.onmessage = (event) => {
 			protocol.handleMessage(String(event.data));
 		};
-		ws.onclose = () => protocol.handleClose();
+		ws.onclose = onClosed;
 		ws.onerror = (event) => {
 			logger.warn("ws error", { event });
-			protocol.handleClose();
+			onClosed();
 		};
 	});
 }


### PR DESCRIPTION
Follow-up to #371 (single-file SQLite), now rebased onto main.

## What
Adds a `/api/metrics` Prometheus endpoint and instruments the sync hot paths: active WS connections gauge; WS messages + accepted-push-docs counters; push/fetch/manifest handler durations + per-op DB latency histograms. Groundwork for Loki/Grafana.

## Hardening (addresses a review finding)
The WS `type` label is allowlisted to the known message kinds (`hello`/`manifest`/`fetch`/`push`/`ping`, else `other`) so a client can't blow up metric cardinality, and label values are escaped in the exposition output. Unit-tested.

## Testing
118 backend tests pass (incl. metrics render + label escaping). Biome clean; `main.ts` type-checks.