### PR TITLE
refactor(frontend): use shared controls

### DIFF
--- a/frontend/src/components/VirtualTableEditor.tsx
+++ b/frontend/src/components/VirtualTableEditor.tsx
@@ -23,6 +23,7 @@ import type { ReactNode } from "react";
 import useTableDensity from "../utils/useTableDensity";
 import type { WithDataTestId } from "./base/Common";
 import Icon from "./base/Icon";
+import { Input } from "./base/Input";
 import { FieldVisibility } from "./editor/FieldDef";
 
 const VirtualizedGrid =
@@ -482,16 +483,13 @@ const RowLineRuler = ({
 			className="pointer-events-none invisible absolute flex items-center gap-2"
 			style={{ left: -9999, top: -9999, width: 200 }}
 		>
-			<div className="flex focus-within:ring-1 focus-within:ring-inset">
-				<div className="grow">
-					<input
-						readOnly
-						tabIndex={-1}
-						value="Mp"
-						className="w-full color-inherit bg-transparent outline-none"
-					/>
-				</div>
-			</div>
+			<Input
+				testId="rowLineRuler"
+				readOnly
+				value="Mp"
+				placeholder=""
+				onChange={() => {}}
+			/>
 			<div className="mn-select">
 				<div className="mn-select__control">
 					<div className="mn-select__value-container">

--- a/frontend/src/components/base/Button.tsx
+++ b/frontend/src/components/base/Button.tsx
@@ -1,5 +1,5 @@
 import { omit } from "lodash";
-import type { ReactNode } from "react";
+import type { ButtonHTMLAttributes, ReactNode } from "react";
 
 import { type TMessages, WithMessages } from "../../utils/Messages";
 import { slugify } from "../../utils/Utils";
@@ -9,14 +9,18 @@ import Space from "./Space";
 
 type ButtonType = "primary" | "secondary" | "link" | "danger";
 
-type ButtonProps = Partial<WithDataTestId> & {
-	onClick: () => void;
-	title?: string;
-	children?: string | ReactNode | ReactNode[];
-	className?: string;
-	disabled?: boolean;
-	compact?: boolean;
-};
+type ButtonProps = Partial<WithDataTestId> &
+	Omit<
+		ButtonHTMLAttributes<HTMLButtonElement>,
+		"children" | "className" | "onClick" | "title" | "type"
+	> & {
+		onClick?: () => void;
+		type?: "button" | "submit" | "reset";
+		title?: string;
+		children?: string | ReactNode | ReactNode[];
+		className?: string;
+		compact?: boolean;
+	};
 
 type WithButtonKind = {
 	kind: ButtonType;
@@ -33,9 +37,9 @@ const Button = ({ kind, ...base }: Partial<ButtonProps> & WithButtonKind) =>
 	function BaseButton(props: ButtonProps) {
 		return (
 			<button
-				type="button"
 				{...omit(base, ["testId", "compact"])}
 				{...omit(props, ["testId", "compact"])}
+				type={props.type || base.type || "button"}
 				data-testid={props.testId || base.testId}
 				disabled={props.disabled}
 				className={`flex whitespace-nowrap rounded ${props.compact ? "" : "p-1"} outline-none focus:ring-2 focus:ring-inset focus:ring-primary-500 ${styles[kind]} ${

--- a/frontend/src/components/base/Input.tsx
+++ b/frontend/src/components/base/Input.tsx
@@ -1,4 +1,9 @@
-import { type ReactNode, useEffect, useState } from "react";
+import {
+	type InputHTMLAttributes,
+	type ReactNode,
+	useEffect,
+	useState,
+} from "react";
 import { NumericFormat } from "react-number-format";
 
 import type { ClassNameType } from "../../utils/Utils";
@@ -123,6 +128,40 @@ const Input = ({
 		),
 	});
 };
+
+export type CheckboxInputProps = WithDataTestId & {
+	checked: boolean;
+	onChange: (checked: boolean) => void;
+	className?: string;
+	disabled?: boolean;
+	readOnly?: boolean;
+};
+
+export const CheckboxInput = ({
+	checked,
+	onChange,
+	className,
+	disabled,
+	readOnly,
+	testId,
+}: CheckboxInputProps) => (
+	<input
+		data-testid={testId}
+		type="checkbox"
+		className={className}
+		checked={checked}
+		disabled={disabled === true || readOnly === true}
+		readOnly={readOnly}
+		onChange={({ target: { checked: newValue } }) => onChange(newValue)}
+	/>
+);
+
+type FileInputProps = Partial<WithDataTestId> &
+	InputHTMLAttributes<HTMLInputElement>;
+
+export const FileInput = ({ testId, ...props }: FileInputProps) => (
+	<input {...props} data-testid={testId} type="file" />
+);
 
 export type InputNumberProps = InputProps<number> & {
 	thousandSeparator: string;

--- a/frontend/src/components/base/Navbar.tsx
+++ b/frontend/src/components/base/Navbar.tsx
@@ -74,10 +74,10 @@ const Navbar = (props: NavbarProps & WithDataTestId) => {
 	return (
 		<>
 			{props.expanded && (
-				<button
-					type="button"
+				<LinkButton
+					compact
 					aria-label="Close menu"
-					className="lg:hidden fixed inset-0 z-30 bg-black/50"
+					className="fixed inset-0 z-30 bg-black/50 no-underline lg:hidden"
 					onClick={props.onCollapse}
 				/>
 			)}

--- a/frontend/src/components/tour/EncryptionGate.tsx
+++ b/frontend/src/components/tour/EncryptionGate.tsx
@@ -530,7 +530,7 @@ export default function EncryptionGate({ store, onUnlocked }: Props) {
 						}}
 					/>
 				)}
-				<button type="submit" hidden />
+				<SecondaryButton type="submit" hidden />
 			</form>
 			{error && (
 				<p className="text-sm text-danger-300" data-testid="encryptionError">

--- a/frontend/src/pages/import/ImportStarter.tsx
+++ b/frontend/src/pages/import/ImportStarter.tsx
@@ -2,6 +2,7 @@ import { head, isEmpty, last } from "lodash";
 import { observer } from "mobx-react-lite";
 import { type Dispatch, useCallback, useState } from "react";
 import { useDropzone } from "react-dropzone";
+import { FileInput } from "../../components/base/Input";
 import Select from "../../components/base/Select";
 import { VerticalSpace } from "../../components/base/Space";
 import { TextSubtitle, TextTitle } from "../../components/base/Text";
@@ -50,7 +51,7 @@ const FileUploader = ({ onFile, error }: FileUploaderProps) => {
 		},
 	});
 
-	const inputProps = { ...getInputProps(), "data-testid": "importFile" };
+	const inputProps = getInputProps();
 
 	return (
 		<>
@@ -59,7 +60,7 @@ const FileUploader = ({ onFile, error }: FileUploaderProps) => {
 				onClick={inputProps.onClick}
 				{...getRootProps()}
 			>
-				<input {...inputProps} />
+				<FileInput testId="importFile" {...inputProps} />
 				<p>
 					<strong>{error}</strong>
 				</p>

--- a/frontend/src/pages/report/ChartLegend.tsx
+++ b/frontend/src/pages/report/ChartLegend.tsx
@@ -1,3 +1,5 @@
+import { LinkButton } from "../../components/base/Button";
+
 import { colorForKey } from "./nivoTheme";
 
 interface ChartLegendProps {
@@ -23,14 +25,14 @@ const ChartLegend = ({
 				const isDimmed = dimmedSeries?.has(s) ?? false;
 				const color = colorMap?.[s] ?? colorForKey(s);
 				return (
-					<button
-						type="button"
+					<LinkButton
+						compact
 						key={s}
 						onClick={() => onToggle(s)}
-						className={`inline-flex items-center gap-1.5 rounded-full bg-background-900 px-2.5 py-1 text-xs transition hover:bg-background-700 ${
+						className={`inline-flex items-center gap-1.5 rounded-full bg-background-900 px-2.5 py-1 text-xs no-underline transition hover:bg-background-700 ${
 							isHidden ? "opacity-40" : ""
 						} ${isDimmed ? "border border-dashed border-foreground/30" : ""}`}
-						data-testid={`legendChip_${s}`}
+						testId={`legendChip_${s}`}
 					>
 						<span
 							className="inline-block h-2.5 w-2.5 rounded-sm"
@@ -44,7 +46,7 @@ const ChartLegend = ({
 						>
 							{s}
 						</span>
-					</button>
+					</LinkButton>
 				);
 			})}
 		</div>

--- a/frontend/src/pages/report/DrillDownPanel.tsx
+++ b/frontend/src/pages/report/DrillDownPanel.tsx
@@ -1,6 +1,7 @@
 import { observer } from "mobx-react-lite";
 import { useMemo } from "react";
 
+import { LinkButton } from "../../components/base/Button";
 import type { ITransaction } from "../../entities/Transaction";
 import useMoneeeyStore from "../../shared/useMoneeeyStore";
 import useMessages from "../../utils/Messages";
@@ -48,14 +49,14 @@ const DrillDownPanel = observer(
 							{periodLabel ?? info.period} · {info.series}
 						</span>
 					</div>
-					<button
-						type="button"
+					<LinkButton
+						compact
 						onClick={onClose}
-						data-testid="drillDownClose"
-						className="rounded bg-background-800 px-2 py-1 text-sm hover:bg-background-700"
+						testId="drillDownClose"
+						className="rounded bg-background-800 px-2 py-1 text-sm no-underline hover:bg-background-700"
 					>
 						{Messages.util.close}
-					</button>
+					</LinkButton>
 				</header>
 
 				{rows.length === 0 ? (

--- a/frontend/src/pages/report/ReportControls.tsx
+++ b/frontend/src/pages/report/ReportControls.tsx
@@ -2,6 +2,7 @@ import { observer } from "mobx-react-lite";
 import { useMemo } from "react";
 
 import DatePicker from "../../components/base/DatePicker";
+import { CheckboxInput } from "../../components/base/Input";
 import Select from "../../components/base/Select";
 import type { IAccount, TAccountUUID } from "../../entities/Account";
 import useMoneeeyStore from "../../shared/useMoneeeyStore";
@@ -278,12 +279,11 @@ const AccountToggle = ({
 				: "border-background-700 bg-background-800 text-foreground/70 hover:bg-background-700"
 		}`}
 	>
-		<input
-			data-testid={`accountVisible_${account.id}`}
-			type="checkbox"
+		<CheckboxInput
+			testId={`accountVisible_${account.id}`}
 			className="m-0 h-3 w-3"
 			checked={selected}
-			onChange={onToggle}
+			onChange={() => onToggle()}
 		/>
 		{account.name}
 	</label>

--- a/frontend/src/pages/report/TagExplorerReport.tsx
+++ b/frontend/src/pages/report/TagExplorerReport.tsx
@@ -1,6 +1,7 @@
 import { observer } from "mobx-react-lite";
 import { useMemo, useState } from "react";
 
+import { LinkButton } from "../../components/base/Button";
 import { AccountKind } from "../../entities/Account";
 import type { ITransaction } from "../../entities/Transaction";
 import useMoneeeyStore from "../../shared/useMoneeeyStore";
@@ -170,23 +171,23 @@ const TagExplorerReport = observer(() => {
 				data-testid="tagExplorerBreadcrumbs"
 				className="flex flex-wrap items-center gap-1 text-sm"
 			>
-				<button
-					type="button"
+				<LinkButton
+					compact
 					onClick={() => setScope(null)}
-					className="rounded px-2 py-1 hover:bg-background-700"
+					className="rounded px-2 py-1 no-underline hover:bg-background-700"
 				>
 					{Messages.util.all}
-				</button>
+				</LinkButton>
 				{breadcrumbs.map((crumb) => (
 					<span key={crumb.path} className="flex items-center gap-1">
 						<span className="opacity-50">›</span>
-						<button
-							type="button"
+						<LinkButton
+							compact
 							onClick={() => setScope(crumb.path)}
-							className="rounded px-2 py-1 hover:bg-background-700"
+							className="rounded px-2 py-1 no-underline hover:bg-background-700"
 						>
 							{crumb.label}
-						</button>
+						</LinkButton>
 					</span>
 				))}
 			</nav>


### PR DESCRIPTION
## Summary
- extend shared base controls for buttons, file inputs, and checkboxes
- replace inline report/import/menu controls with shared components
- keep shared-control branch independent of abandoned Playwright video-reporting changes

## Verification
- /frb/p/moneeey/node_modules/.bin/biome ci .
- cd frontend && yarn lint