### PR TITLE
test(playwright): seed e2e setup state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 
 # testing
 /coverage
+/frontend/coverage
+/playwright/coverage
 
 # production
 /build

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
 		"build": "tsc && vite build",
 		"preview": "vite preview",
 		"test": "TZ=America/Sao_Paulo jest",
+		"test:coverage": "TZ=America/Sao_Paulo jest --coverage",
 		"lint": "tsc"
 	},
 	"dependencies": {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import type { UnlockResult } from "./components/tour/EncryptionGate";
 import MoneeeyStore from "./shared/MoneeeyStore";
 import { LocalStore } from "./shared/storage/LocalStore";
 import { getTabLocalStoreName } from "./shared/storage/tabVault";
+import { moneeeySetupTestEnvironment } from "./shared/testEnvironment";
 import useMoneeeyStore, {
 	MoneeeyStoreProvider,
 } from "./shared/useMoneeeyStore";
@@ -96,7 +97,7 @@ const AppContent = observer(() => {
 });
 
 const AppBoot = observer(() => {
-	const { currentLanguage } = useLanguageSwitcher();
+	const { currentLanguage, selectLanguage } = useLanguageSwitcher();
 	const [moneeeyStore, setMoneeeyStore] = useState<MoneeeyStore | null>(null);
 	const [localStoreReady, setLocalStoreReady] = useState(false);
 	const localStore = useMemo(() => new LocalStore(getTabLocalStoreName()), []);
@@ -110,6 +111,20 @@ const AppBoot = observer(() => {
 			cancelled = true;
 		};
 	}, [localStore]);
+
+	useEffect(() => {
+		if (!import.meta.env.DEV) return;
+		window.moneeeySetupTestEnvironment = (options) =>
+			moneeeySetupTestEnvironment({
+				...options,
+				localStore,
+				selectLanguage,
+				setMoneeeyStore,
+			});
+		return () => {
+			window.moneeeySetupTestEnvironment = undefined;
+		};
+	}, [localStore, selectLanguage]);
 
 	const onUnlocked = useCallback(
 		async ({ dataKey, syncConfig }: UnlockResult) => {

--- a/frontend/src/shared/storage/LocalStore.ts
+++ b/frontend/src/shared/storage/LocalStore.ts
@@ -114,6 +114,11 @@ export class LocalStore implements MetaStore {
 		await clearStore(this.requireDb(), STORE_DOCUMENTS);
 	}
 
+	async clearAll(): Promise<void> {
+		await clearStore(this.requireDb(), STORE_DOCUMENTS);
+		await clearStore(this.requireDb(), STORE_META);
+	}
+
 	async getVaultId(): Promise<string | undefined> {
 		return await getValue<string>(this.requireDb(), STORE_META, META_VAULT_ID);
 	}

--- a/frontend/src/shared/testEnvironment.ts
+++ b/frontend/src/shared/testEnvironment.ts
@@ -1,0 +1,204 @@
+import { AccountKind, type IAccount } from "../entities/Account";
+import type { ICurrency } from "../entities/Currency";
+import type { ITransaction } from "../entities/Transaction";
+import { currentDate } from "../utils/Date";
+import type { LanguageCode } from "../utils/Messages";
+import { StorageKind, setStorage } from "../utils/Utils";
+import MoneeeyStore from "./MoneeeyStore";
+import { setupNewEncryption } from "./encryption/codec";
+import type { LocalStore } from "./storage/LocalStore";
+
+type TSeedAccount = Partial<IAccount> & {
+	name: string;
+	currency?: string;
+	initialBalance?: number;
+};
+
+type TSeedTransaction = Partial<ITransaction> & {
+	from: string;
+	to: string;
+	amount?: number;
+	fromValue?: number;
+	toValue?: number;
+};
+
+export type TTestEnvironmentOptions = {
+	passphrase?: string;
+	accounts?: TSeedAccount[];
+	transactions?: TSeedTransaction[];
+	skipTour?: boolean;
+};
+
+type TBootstrappedTestEnvironmentOptions = TTestEnvironmentOptions & {
+	localStore: LocalStore;
+	selectLanguage: (code: LanguageCode) => void;
+	setMoneeeyStore: (store: MoneeeyStore) => void;
+};
+
+const DEFAULT_TEST_PASSPHRASE = "playwright-test-pass-123";
+
+const defaultAccounts: TSeedAccount[] = [
+	{
+		id: "test-account-01-banco",
+		name: "Banco Moneeey",
+		currency: "BRL",
+		initialBalance: 1234.56,
+	},
+	{
+		id: "test-account-02-card",
+		name: "MoneeeyCard",
+		currency: "BRL",
+		initialBalance: 2000,
+	},
+	{
+		id: "test-account-03-bitcoin",
+		name: "Bitcoinss",
+		currency: "BTC",
+		initialBalance: 0.12345678,
+	},
+];
+
+const currencyByName = (store: MoneeeyStore, name: string): ICurrency => {
+	const currency = store.currencies.findByName(name);
+	if (!currency) throw new Error(`Test currency not found: ${name}`);
+	return currency;
+};
+
+const ensureAccount = (
+	store: MoneeeyStore,
+	seed: TSeedAccount,
+	defaultCurrency: ICurrency,
+) => {
+	const {
+		currency: _currency,
+		initialBalance: _initialBalance,
+		...accountSeed
+	} = seed;
+	const currency = seed.currency
+		? currencyByName(store, seed.currency)
+		: defaultCurrency;
+	const account = store.accounts.factory(seed.id);
+	store.accounts.merge({
+		...account,
+		...accountSeed,
+		id: seed.id ?? account.id,
+		name: seed.name,
+		created: accountSeed.created ?? account.created,
+		kind: seed.kind ?? AccountKind.CHECKING,
+		currency_uuid: seed.currency_uuid ?? currency.id,
+	});
+	return store.accounts.byUuid(seed.id ?? account.id) ?? account;
+};
+
+const addInitialBalance = (
+	store: MoneeeyStore,
+	currency: ICurrency,
+	account: IAccount,
+	amount: number,
+) => {
+	const initialAccountId = `test-initial-balance-${currency.short}`;
+	const initialAccount = store.accounts.factory(initialAccountId);
+	store.accounts.merge({
+		...initialAccount,
+		name: `Initial balance ${currency.short}`,
+		kind: AccountKind.PAYEE,
+		currency_uuid: currency.id,
+	});
+	const transaction = store.transactions.factory(
+		`test-transaction-initial-${account.id}`,
+	);
+	store.transactions.merge({
+		...transaction,
+		from_account: initialAccountId,
+		from_value: amount,
+		to_account: account.id,
+		to_value: amount,
+	});
+};
+
+const accountBySeedRef = (store: MoneeeyStore, ref: string) => {
+	const account = store.accounts.byUuid(ref) ?? store.accounts.byName(ref);
+	if (!account) throw new Error(`Test account not found: ${ref}`);
+	return account;
+};
+
+const seedTransaction = (
+	store: MoneeeyStore,
+	seed: TSeedTransaction,
+	index: number,
+) => {
+	const {
+		from: fromRef,
+		to: toRef,
+		amount,
+		fromValue,
+		toValue,
+		...txSeed
+	} = seed;
+	const from = accountBySeedRef(store, fromRef);
+	const to = accountBySeedRef(store, toRef);
+	const defaultAmount = amount ?? 0;
+	const transaction = store.transactions.factory(
+		seed.id ?? `test-transaction-${String(index).padStart(2, "0")}`,
+	);
+	store.transactions.merge({
+		...transaction,
+		...txSeed,
+		id: seed.id ?? transaction.id,
+		date: seed.date ?? currentDate(),
+		from_account: from.id,
+		to_account: to.id,
+		from_value: fromValue ?? seed.from_value ?? defaultAmount,
+		to_value: toValue ?? seed.to_value ?? defaultAmount,
+		memo: seed.memo ?? "",
+	});
+};
+
+export async function moneeeySetupTestEnvironment({
+	localStore,
+	selectLanguage,
+	setMoneeeyStore,
+	passphrase = DEFAULT_TEST_PASSPHRASE,
+	accounts = defaultAccounts,
+	transactions = [],
+	skipTour = true,
+}: TBootstrappedTestEnvironmentOptions) {
+	setStorage("language", "en", StorageKind.PERMANENT);
+	if (skipTour) setStorage("landing", "true", StorageKind.PERMANENT);
+	selectLanguage("en");
+
+	await localStore.open();
+	await localStore.clearAll();
+	const dataKey = await setupNewEncryption(localStore, passphrase);
+	const store = new MoneeeyStore(localStore);
+	store.persistence.setDataKey(dataKey);
+	await store.load();
+
+	const brl = currencyByName(store, "BRL");
+	store.config.merge({ ...store.config.main, default_currency: brl.id });
+
+	for (const seed of accounts) {
+		const account = ensureAccount(store, seed, brl);
+		if (seed.initialBalance !== undefined) {
+			addInitialBalance(
+				store,
+				store.currencies.byUuid(account.currency_uuid) ?? brl,
+				account,
+				seed.initialBalance,
+			);
+		}
+	}
+
+	transactions.forEach((seed, index) => seedTransaction(store, seed, index));
+	await store.persistence.flush();
+	setMoneeeyStore(store);
+	window.location.hash = "/dashboard";
+}
+
+declare global {
+	interface Window {
+		moneeeySetupTestEnvironment?: (
+			options?: TTestEnvironmentOptions,
+		) => Promise<void>;
+	}
+}

--- a/playwright/helpers/passkey-flows.ts
+++ b/playwright/helpers/passkey-flows.ts
@@ -4,6 +4,7 @@ import { E2E_PASSPHRASE } from "./wizard";
 
 export async function landThroughLanguage(page: Page) {
 	await page.getByTestId("languageSelector_en").click();
+	await page.evaluate(() => window.localStorage.setItem("landing", "true"));
 	await page.getByTestId("ok-button").click();
 }
 
@@ -37,7 +38,6 @@ export async function createFirstAccount(page: Page, name: string) {
 		timeout: 5_000,
 	});
 	await page.getByTestId("save-and-close").click();
-	await dismissLandingTour(page);
 }
 
 export async function dismissLandingTour(page: Page) {

--- a/playwright/helpers/setup.ts
+++ b/playwright/helpers/setup.ts
@@ -21,7 +21,12 @@ export async function resetAppState(page: Page) {
 			if (db.name?.startsWith("moneeey")) names.add(db.name);
 		}
 		for (const name of names) {
-			window.indexedDB.deleteDatabase(name);
+			await new Promise<void>((resolve, reject) => {
+				const request = window.indexedDB.deleteDatabase(name);
+				request.onsuccess = () => resolve();
+				request.onerror = () => reject(request.error);
+				request.onblocked = () => resolve();
+			});
 		}
 	});
 }

--- a/playwright/helpers/test-fixtures.ts
+++ b/playwright/helpers/test-fixtures.ts
@@ -1,4 +1,6 @@
-import { type Page, test as base } from "@playwright/test";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { type CDPSession, type Page, test as base } from "@playwright/test";
 import { step } from "./perf";
 import { resetAppState } from "./setup";
 import {
@@ -19,7 +21,46 @@ type MoneeeyFixtures = {
 	transactionsPage: Page;
 };
 
+const coverageEnabled = process.env.PW_COVERAGE === "on";
+
+const safeFilePart = (value: string) =>
+	value.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-|-$/g, "");
+
 export const test = base.extend<MoneeeyFixtures>({
+	page: async ({ page, browserName }, use, testInfo) => {
+		let coverageSession: CDPSession | undefined;
+		const shouldCollect = coverageEnabled && browserName === "chromium";
+		if (shouldCollect) {
+			coverageSession = await page.context().newCDPSession(page);
+			await coverageSession.send("Profiler.enable");
+			await coverageSession.send("Profiler.startPreciseCoverage", {
+				callCount: true,
+				detailed: true,
+			});
+		}
+		try {
+			await use(page);
+		} finally {
+			if (coverageSession) {
+				const coverage = await coverageSession.send(
+					"Profiler.takePreciseCoverage",
+				);
+				await coverageSession.send("Profiler.stopPreciseCoverage");
+				await coverageSession.send("Profiler.disable");
+				const coverageDir = path.join(process.cwd(), "coverage", "playwright");
+				await mkdir(coverageDir, { recursive: true });
+				const coveragePath = path.join(
+					coverageDir,
+					`${safeFilePart(testInfo.project.name)}-${safeFilePart(testInfo.title)}.json`,
+				);
+				await writeFile(coveragePath, `${JSON.stringify(coverage, null, 2)}\n`);
+				await testInfo.attach("js-coverage", {
+					path: coveragePath,
+					contentType: "application/json",
+				});
+			}
+		}
+	},
 	seededPage: async ({ page }, use) => {
 		await step("reset app state", () => resetAppState(page));
 		await use(page);

--- a/playwright/helpers/test-fixtures.ts
+++ b/playwright/helpers/test-fixtures.ts
@@ -1,17 +1,22 @@
 import { type Page, test as base } from "@playwright/test";
-import { closeTourModal } from "./page-objects";
 import { step } from "./perf";
 import { resetAppState } from "./setup";
-import { completeLandingWizard } from "./wizard";
+import {
+	defaultTransactionAccounts,
+	defaultTransactions,
+	seedTestEnvironment,
+} from "./wizard";
 
 /**
  * - `seededPage`: fresh app at `/` with storage wiped. Use for tests that
  *   exercise the landing wizard itself (tour.spec.ts).
- * - `wizardPage`: post-wizard Dashboard — reset + wizard + close tour modal.
+ * - `wizardPage`: post-wizard Dashboard — reset + frontend test seed.
+ * - `transactionsPage`: `wizardPage` plus a stable set of transaction rows.
  */
 type MoneeeyFixtures = {
 	seededPage: Page;
 	wizardPage: Page;
+	transactionsPage: Page;
 };
 
 export const test = base.extend<MoneeeyFixtures>({
@@ -21,8 +26,17 @@ export const test = base.extend<MoneeeyFixtures>({
 	},
 	wizardPage: async ({ page }, use) => {
 		await step("reset app state", () => resetAppState(page));
-		await step("complete landing wizard", () => completeLandingWizard(page));
-		await step("close tour modal", () => closeTourModal(page));
+		await step("seed test environment", () => seedTestEnvironment(page));
+		await use(page);
+	},
+	transactionsPage: async ({ page }, use) => {
+		await step("reset app state", () => resetAppState(page));
+		await step("seed transaction test environment", () =>
+			seedTestEnvironment(page, {
+				accounts: defaultTransactionAccounts,
+				transactions: defaultTransactions,
+			}),
+		);
 		await use(page);
 	},
 });

--- a/playwright/helpers/wizard.ts
+++ b/playwright/helpers/wizard.ts
@@ -4,6 +4,124 @@ import { Input, Select } from "./page-objects";
 
 export const E2E_PASSPHRASE = "playwright-test-pass-123";
 
+type SeedAccount = {
+	id?: string;
+	name: string;
+	currency?: string;
+	kind?: "CHECKING" | "INVESTMENT" | "SAVINGS" | "CREDIT_CARD" | "PAYEE";
+	initialBalance?: number;
+};
+
+type SeedTransaction = {
+	id?: string;
+	from: string;
+	to: string;
+	amount?: number;
+	fromValue?: number;
+	toValue?: number;
+	date?: string;
+	memo?: string;
+};
+
+type SeedTestEnvironmentOptions = {
+	passphrase?: string;
+	accounts?: SeedAccount[];
+	transactions?: SeedTransaction[];
+	skipTour?: boolean;
+};
+
+type TestEnvironmentWindow = Window & {
+	moneeeySetupTestEnvironment?: (
+		options?: SeedTestEnvironmentOptions,
+	) => Promise<void>;
+};
+
+export const defaultSeedAccounts: SeedAccount[] = [
+	{
+		id: "test-account-01-banco",
+		name: "Banco Moneeey",
+		currency: "BRL",
+		initialBalance: 1234.56,
+	},
+	{
+		id: "test-account-02-card",
+		name: "MoneeeyCard",
+		currency: "BRL",
+		initialBalance: 2000,
+	},
+	{
+		id: "test-account-03-bitcoin",
+		name: "Bitcoinss",
+		currency: "BTC",
+		initialBalance: 0.12345678,
+	},
+];
+
+export const defaultTransactionAccounts: SeedAccount[] = [
+	...defaultSeedAccounts,
+	{ id: "test-payee-bakery", name: "Bakery123", kind: "PAYEE" },
+	{ id: "test-payee-ristorant", name: "Ristorant88", kind: "PAYEE" },
+	{ id: "test-payee-playxbox", name: "Playxbox421", kind: "PAYEE" },
+	{ id: "test-payee-cashback", name: "Cashbazk", kind: "PAYEE" },
+];
+
+export const defaultTransactions: SeedTransaction[] = [
+	{
+		id: "test-transaction-card-income",
+		from: "Banco Moneeey",
+		to: "MoneeeyCard",
+		amount: 3000,
+	},
+	{
+		id: "test-transaction-card-bakery",
+		from: "MoneeeyCard",
+		to: "Bakery123",
+		amount: 60,
+		memo: "pao",
+	},
+	{
+		id: "test-transaction-card-dinner",
+		from: "MoneeeyCard",
+		to: "Ristorant88",
+		amount: 128,
+	},
+	{
+		id: "test-transaction-card-playxbox",
+		from: "MoneeeyCard",
+		to: "Playxbox421",
+		amount: 7213.21,
+	},
+	{
+		id: "test-transaction-card-cashback",
+		from: "Cashbazk",
+		to: "MoneeeyCard",
+		amount: 69.42,
+		memo: "cashback",
+	},
+];
+
+export async function seedTestEnvironment(
+	page: Page,
+	options: SeedTestEnvironmentOptions = {},
+) {
+	await page.goto("/#/dashboard");
+	await page.waitForFunction(
+		() =>
+			typeof (window as TestEnvironmentWindow).moneeeySetupTestEnvironment ===
+			"function",
+	);
+	await page.evaluate(
+		async (setupOptions) => {
+			const setup = (window as TestEnvironmentWindow)
+				.moneeeySetupTestEnvironment;
+			if (!setup) throw new Error("moneeeySetupTestEnvironment unavailable");
+			await setup(setupOptions);
+		},
+		{ passphrase: E2E_PASSPHRASE, ...options },
+	);
+	await expect(page.getByText("Dashboard")).toBeVisible();
+}
+
 export async function completeEncryptionSetup(
 	page: Page,
 	passphrase: string = E2E_PASSPHRASE,

--- a/playwright/package.json
+++ b/playwright/package.json
@@ -14,6 +14,7 @@
 		"test": "playwright test",
 		"test-ff": "playwright test --project firefox --reporter list",
 		"test-cr": "playwright test --project chromium --reporter list",
+		"test:coverage": "PW_COVERAGE=on playwright test --project chromium",
 		"test-perf": "PERF_LOG=1 playwright test --reporter=list",
 		"debug-ff": "playwright test --headed --timeout 0 --project firefox",
 		"debug-cr": "playwright test --headed --timeout 0 --project chromium"

--- a/playwright/tests/accounts.spec.ts
+++ b/playwright/tests/accounts.spec.ts
@@ -5,17 +5,30 @@ import {
 	OpenMenuItem,
 	Select,
 	clickMenuByTestId,
+	defaultSeedAccounts,
 	expect,
 	retrieveRowsData,
+	seedTestEnvironment,
 	test,
-	updateOnAccountTransactions,
 } from "../helpers";
 
 const ACCOUNTS_MENU_TESTID = "appMenu_subitems_settings_settings_accounts";
 
 test("Account settings — rename, archive, merge", async ({
-	wizardPage: page,
+	seededPage: page,
 }) => {
+	await seedTestEnvironment(page, {
+		accounts: defaultSeedAccounts,
+		transactions: [
+			{
+				id: "test-transaction-merge-target",
+				from: "Banco Moneeey",
+				to: "MoneeeyCard",
+				amount: 500,
+			},
+		],
+	});
+
 	// Navigate to Settings > Accounts (by testId to avoid "Include accounts:" text clash)
 	await clickMenuByTestId(page, ACCOUNTS_MENU_TESTID);
 
@@ -43,10 +56,6 @@ test("Account settings — rename, archive, merge", async ({
 	// Archive Bitcoinss via the Archived checkbox
 	await page.getByTestId("editorArchived").nth(1).click();
 	await expect(sidebar.getByText("BTC Bitcoinss")).not.toBeVisible();
-
-	// Add a transaction on Banco Principal to test merge reassignment
-	await sidebar.getByText("BRL Banco Principal").click();
-	await updateOnAccountTransactions(page, 1, "MoneeeyCard", "-500");
 
 	// Merge Banco Principal → MoneeeyCard
 	await clickMenuByTestId(page, ACCOUNTS_MENU_TESTID);

--- a/playwright/tests/budgets.spec.ts
+++ b/playwright/tests/budgets.spec.ts
@@ -5,20 +5,47 @@ import {
 	OpenMenuItem,
 	Select,
 	budgetEditorSave,
+	defaultSeedAccounts,
 	expect,
 	retrieveRowsData,
+	seedTestEnvironment,
 	test,
-	updateOnAllTransactions,
 	withBudgetEditor,
 } from "../helpers";
 
+async function seedBudgetTransactions(
+	page: import("@playwright/test").Page,
+	transactions: { id: string; from: string; to: string; amount: number }[],
+) {
+	await seedTestEnvironment(page, {
+		accounts: [
+			...defaultSeedAccounts,
+			{ id: "test-payee-gas-station", name: "Gas Station", kind: "PAYEE" },
+			{ id: "test-payee-bakery", name: "Bakery", kind: "PAYEE" },
+		],
+		transactions,
+	});
+}
+
 test("Budget lifecycle — create, allocate, open editor, view archived toggle", async ({
-	wizardPage: page,
+	seededPage: page,
 }) => {
-	// Add transactions for budget testing
+	await seedBudgetTransactions(page, [
+		{
+			id: "test-transaction-gas-station",
+			from: "Banco Moneeey",
+			to: "Gas Station",
+			amount: 100,
+		},
+		{
+			id: "test-transaction-bakery",
+			from: "Banco Moneeey",
+			to: "Bakery",
+			amount: 50,
+		},
+	]);
+
 	await OpenMenuItem(page, "All transactions");
-	await updateOnAllTransactions(page, 3, "Banco Moneeey", "Gas Station", "100");
-	await updateOnAllTransactions(page, 4, "Banco Moneeey", "Bakery", "50");
 
 	// Verify the transactions are correct before checking budgets
 	const today = formatDate(new Date());
@@ -66,11 +93,22 @@ test("Budget lifecycle — create, allocate, open editor, view archived toggle",
 });
 
 test("Budget — zero-allocation persists, tag swap recalculates used, archive shows indicator", async ({
-	wizardPage: page,
+	seededPage: page,
 }) => {
-	await OpenMenuItem(page, "All transactions");
-	await updateOnAllTransactions(page, 3, "Banco Moneeey", "Bakery", "100");
-	await updateOnAllTransactions(page, 4, "Banco Moneeey", "Gas Station", "42");
+	await seedBudgetTransactions(page, [
+		{
+			id: "test-transaction-bakery",
+			from: "Banco Moneeey",
+			to: "Bakery",
+			amount: 100,
+		},
+		{
+			id: "test-transaction-gas-station",
+			from: "Banco Moneeey",
+			to: "Gas Station",
+			amount: 42,
+		},
+	]);
 
 	await OpenMenuItem(page, "Budget");
 	await budgetEditorSave(page, "Food", "Bakery");

--- a/playwright/tests/compact-density.spec.ts
+++ b/playwright/tests/compact-density.spec.ts
@@ -2,13 +2,13 @@ import {
 	BudgetRow,
 	Input,
 	OpenMenuItem,
-	Select,
 	budgetEditorSave,
 	clickMenuByTestId,
+	defaultSeedAccounts,
 	expect,
 	retrieveRowsData,
+	seedTestEnvironment,
 	test,
-	updateOnAllTransactions,
 } from "../helpers";
 
 const SETTINGS_MENU_TESTID = "appMenu_subitems_settings_settings_general";
@@ -162,10 +162,22 @@ test("Compact density — persistence, active ring, and table structure across v
 });
 
 test("Compact budget — rows allocate, used and remaining stay in sync", async ({
-	wizardPage: page,
+	seededPage: page,
 }) => {
-	await OpenMenuItem(page, "All transactions");
-	await updateOnAllTransactions(page, 3, "Banco Moneeey", "Cafe", "30");
+	await seedTestEnvironment(page, {
+		accounts: [
+			...defaultSeedAccounts,
+			{ id: "test-payee-cafe", name: "Cafe", kind: "PAYEE" },
+		],
+		transactions: [
+			{
+				id: "test-transaction-cafe",
+				from: "Banco Moneeey",
+				to: "Cafe",
+				amount: 30,
+			},
+		],
+	});
 
 	await setDensity(page, "compact");
 	await OpenMenuItem(page, "Budget");
@@ -184,17 +196,22 @@ test("Compact budget — rows allocate, used and remaining stay in sync", async 
 });
 
 test("Compact multi-currency — from and to amounts edit independently", async ({
-	wizardPage: page,
+	seededPage: page,
 }) => {
 	// Firefox CI needs extra headroom for react-select + row-remount cascades.
 	test.setTimeout(90_000);
 
-	// Pick accounts with different currencies while still in full mode so the
-	// editor* selects resolve; afterwards we switch to compact where the
-	// TransactionAmountField splits into editorFrom_amount and editorTo_amount.
-	await OpenMenuItem(page, "All transactions");
-	await Select(page, "editorFrom", 3).chooseOrCreate("Banco Moneeey"); // BRL
-	await Select(page, "editorTo", 3).chooseOrCreate("Bitcoinss"); // BTC
+	await seedTestEnvironment(page, {
+		transactions: [
+			{
+				id: "test-transaction-compact-brl-btc",
+				from: "Banco Moneeey",
+				to: "Bitcoinss",
+				fromValue: 0,
+				toValue: 0,
+			},
+		],
+	});
 
 	await setDensity(page, "compact");
 	await OpenMenuItem(page, "All transactions");

--- a/playwright/tests/dashboard.spec.ts
+++ b/playwright/tests/dashboard.spec.ts
@@ -1,34 +1,34 @@
 import { formatDate } from "../../frontend/src/utils/Date";
 import {
 	ALL_TRANSACTIONS_COLUMNS,
-	OpenMenuItem,
+	defaultSeedAccounts,
 	expect,
 	retrieveRowsData,
+	seedTestEnvironment,
 	test,
-	updateOnAccountTransactions,
 } from "../helpers";
 
-test("Dashboard shows recent transactions and updates after new entries", async ({
-	wizardPage: page,
-}) => {
+test("Dashboard shows recent transactions", async ({ seededPage: page }) => {
+	await seedTestEnvironment(page, {
+		accounts: [
+			...defaultSeedAccounts,
+			{ id: "test-payee-bakery", name: "Bakery123", kind: "PAYEE" },
+		],
+		transactions: [
+			{
+				id: "test-transaction-dashboard-bread",
+				from: "MoneeeyCard",
+				to: "Bakery123",
+				amount: 50,
+				memo: "bread",
+			},
+		],
+	});
+
 	// Dashboard is the landing page after wizard — "Recent transactions" heading is visible
 	await expect(page.getByText("Recent transactions")).toBeVisible();
 
-	// Verify the 3 initial balance transactions show up in recent
 	const today = formatDate(new Date());
-	expect(await retrieveRowsData(page, ALL_TRANSACTIONS_COLUMNS, 3)).toEqual([
-		`date: ${today} (bg---800) | from: Initial balance BRL (bg---800) | to: Banco Moneeey (bg---800) | amount: 1.234,56 (bg---800) | memo:  (bg---800)`,
-		`date: ${today} (bg---600) | from: Initial balance BRL (bg---600) | to: MoneeeyCard (bg---600) | amount: 2.000 (bg---600) | memo:  (bg---600)`,
-		`date: ${today} (bg---800) | from: Initial balance BTC (bg---800) | to: Bitcoinss (bg---800) | amount: 0,12345678 (bg---800) | memo:  (bg---800)`,
-	]);
-
-	// Add a transaction and verify it shows up on Dashboard
-	await OpenMenuItem(page, "BRL MoneeeyCard");
-	await updateOnAccountTransactions(page, 1, "Bakery123", "-50", "bread");
-
-	await OpenMenuItem(page, "Dashboard");
-	await expect(page.getByText("Recent transactions")).toBeVisible();
-
 	expect(await retrieveRowsData(page, ALL_TRANSACTIONS_COLUMNS, 4)).toEqual([
 		`date: ${today} (bg---800) | from: Initial balance BRL (bg---800) | to: Banco Moneeey (bg---800) | amount: 1.234,56 (bg---800) | memo:  (bg---800)`,
 		`date: ${today} (bg---600) | from: Initial balance BRL (bg---600) | to: MoneeeyCard (bg---600) | amount: 2.000 (bg---600) | memo:  (bg---600)`,

--- a/playwright/tests/multi-currency.spec.ts
+++ b/playwright/tests/multi-currency.spec.ts
@@ -2,29 +2,52 @@ import {
 	BudgetRow,
 	Input,
 	OpenMenuItem,
-	Select,
 	budgetEditorSave,
 	clickMenuByTestId,
+	defaultSeedAccounts,
+	seedTestEnvironment,
 	test,
-	updateOnAllTransactions,
 } from "../helpers";
 
 test("Multi-currency transactions in both directions with budget tracking", async ({
-	wizardPage: page,
+	seededPage: page,
 }) => {
 	// Firefox CI needs extra headroom for react-select + row-remount cascades.
 	test.setTimeout(90_000);
 
-	// Same-currency row first so multi-currency amount indices are predictable.
+	await seedTestEnvironment(page, {
+		accounts: [
+			...defaultSeedAccounts,
+			{ id: "test-payee-gas-station", name: "Gas Station", kind: "PAYEE" },
+		],
+		transactions: [
+			{
+				id: "test-transaction-gas-station",
+				from: "Banco Moneeey",
+				to: "Gas Station",
+				amount: 200,
+			},
+			{
+				id: "test-transaction-brl-btc",
+				from: "Banco Moneeey",
+				to: "Bitcoinss",
+				fromValue: 0,
+				toValue: 0,
+			},
+			{
+				id: "test-transaction-btc-brl",
+				from: "Bitcoinss",
+				to: "MoneeeyCard",
+				fromValue: 0,
+				toValue: 0,
+			},
+		],
+	});
+
+	// Same-currency row first keeps multi-currency amount indices predictable.
 	await clickMenuByTestId(page, "appMenu_subitems_transactions_all");
-	await updateOnAllTransactions(page, 3, "Banco Moneeey", "Gas Station", "200");
 
 	// === Direction 1: BRL → BTC ===
-	// Row 4 is the new empty row. Setting accounts with different currencies
-	// makes the amount column render two side-by-side editorAmount inputs.
-	await Select(page, "editorFrom", 4).chooseOrCreate("Banco Moneeey");
-	await Select(page, "editorTo", 4).chooseOrCreate("Bitcoinss");
-
 	// editorAmount indices: 0,1,2 = 3 initial balances, 3 = Gas Station (single)
 	// Row 4 has two amount inputs: index 4 = BRL from, index 5 = BTC to
 	await Input(page, "editorAmount", undefined, 4).change("100");
@@ -40,9 +63,6 @@ test("Multi-currency transactions in both directions with budget tracking", asyn
 
 	// === Direction 2: BTC → BRL ===
 	await clickMenuByTestId(page, "appMenu_subitems_transactions_all");
-	await Select(page, "editorFrom", 5).chooseOrCreate("Bitcoinss");
-	await Select(page, "editorTo", 5).chooseOrCreate("MoneeeyCard");
-
 	// Row 5 amount indices: index 6 = BTC from, index 7 = BRL to
 	// (Row 4 consumed two amount indices because it's multi-currency)
 	await Input(page, "editorAmount", undefined, 6).change("0,05000000", "0,05");

--- a/playwright/tests/offline.spec.ts
+++ b/playwright/tests/offline.spec.ts
@@ -23,7 +23,6 @@ import {
 import {
 	BACKEND_REACHABLE,
 	createFirstAccount,
-	dismissLandingTour,
 	landThroughLanguage,
 	pickDefaultCurrencyBRL,
 	signupViaPasskey,
@@ -120,7 +119,6 @@ test.describe("PWA offline", () => {
 			).toHaveCount(0);
 			await pageA.getByTestId("encryptionPassphrase").fill(E2E_PASSPHRASE);
 			await pageA.getByRole("button", { name: "Unlock" }).click();
-			await dismissLandingTour(pageA);
 
 			await waitForSyncStatus(pageA, "offline");
 
@@ -161,7 +159,6 @@ test.describe("PWA offline", () => {
 			).toHaveCount(0);
 			await pageB.getByTestId("encryptionPassphrase").fill(E2E_PASSPHRASE);
 			await pageB.getByRole("button", { name: "Unlock" }).click();
-			await dismissLandingTour(pageB);
 			await waitForSyncStatus(pageB, "online");
 
 			await OpenMenuItem(pageB, `BRL ${accountName}`);

--- a/playwright/tests/profile.spec.ts
+++ b/playwright/tests/profile.spec.ts
@@ -14,7 +14,7 @@ async function pickLanguageEn(page: import("@playwright/test").Page) {
 	await page.getByTestId("ok-button").click();
 }
 
-test("Settings — language, theme, tour, sign out cancel + confirm", async ({
+test("Settings — language, theme, sign out cancel + confirm", async ({
 	wizardPage: page,
 }) => {
 	await clickMenuByTestId(page, SETTINGS_MENU_TESTID);
@@ -31,12 +31,6 @@ test("Settings — language, theme, tour, sign out cancel + confirm", async ({
 		await page.getByTestId("languageSelector_pt").click();
 		await expect(page.getByTestId("settingsTabs_data")).toContainText("Dados");
 		await page.getByTestId("languageSelector_en").click();
-	});
-
-	await test.step("tour button opens modal", async () => {
-		await page.getByRole("button", { name: /tour/i }).click();
-		await expect(page.getByTestId("nm-modal-card")).toBeVisible();
-		await page.getByTestId("nm-modal-card").getByTestId("close").click();
 	});
 
 	await test.step("sign out — cancel leaves app intact", async () => {

--- a/playwright/tests/reports.spec.ts
+++ b/playwright/tests/reports.spec.ts
@@ -44,7 +44,7 @@ const REPORT_TABS = [
 
 test.describe("Reports", () => {
 	test("each report tab renders a chart with seeded data", async ({
-		wizardPage: page,
+		transactionsPage: page,
 	}) => {
 		const sink = trackConsole(page);
 		await OpenMenuItem(page, "Reports");
@@ -66,7 +66,7 @@ test.describe("Reports", () => {
 	});
 
 	test("date range preset switch reflects in URL and re-renders chart", async ({
-		wizardPage: page,
+		transactionsPage: page,
 	}) => {
 		const sink = trackConsole(page);
 		await OpenMenuItem(page, "Reports");
@@ -80,7 +80,7 @@ test.describe("Reports", () => {
 	});
 
 	test("period selector changes bucket granularity without crash", async ({
-		wizardPage: page,
+		transactionsPage: page,
 	}) => {
 		const sink = trackConsole(page);
 		await OpenMenuItem(page, "Reports");
@@ -94,7 +94,7 @@ test.describe("Reports", () => {
 	});
 
 	test("legend chip toggles a series without crash", async ({
-		wizardPage: page,
+		transactionsPage: page,
 	}) => {
 		const sink = trackConsole(page);
 		await OpenMenuItem(page, "Reports");
@@ -116,7 +116,7 @@ test.describe("Reports", () => {
 	});
 
 	test("clicking a bar opens an inline drill-down with transactions", async ({
-		wizardPage: page,
+		transactionsPage: page,
 	}) => {
 		const sink = trackConsole(page);
 		await OpenMenuItem(page, "Reports");
@@ -141,7 +141,7 @@ test.describe("Reports", () => {
 	});
 
 	test("compare-to overlay adds ghost series and dimmed legend chips", async ({
-		wizardPage: page,
+		transactionsPage: page,
 	}) => {
 		const sink = trackConsole(page);
 		await OpenMenuItem(page, "Reports");
@@ -170,7 +170,7 @@ test.describe("Reports", () => {
 	});
 
 	test("tag depth selector on Tag expenses survives a round-trip", async ({
-		wizardPage: page,
+		transactionsPage: page,
 	}) => {
 		const sink = trackConsole(page);
 		await OpenMenuItem(page, "Reports");

--- a/playwright/tests/sync.spec.ts
+++ b/playwright/tests/sync.spec.ts
@@ -24,7 +24,6 @@ import {
 	BACKEND_REACHABLE,
 	addAccountFromSettings,
 	createFirstAccount,
-	dismissLandingTour,
 	landThroughLanguage,
 	openAccountSettings,
 	pickDefaultCurrencyBRL,
@@ -153,10 +152,12 @@ test.describe("passkey cross-context sync", () => {
 			).toHaveCount(0);
 			await pageB.getByTestId("encryptionPassphrase").fill(E2E_PASSPHRASE);
 			await pageB.getByRole("button", { name: "Unlock" }).click();
-			await dismissLandingTour(pageB);
 
-			const hashAfter = await pageB.evaluate(() => window.location.hash);
-			expect(hashAfter).not.toMatch(/^#\/invite\//);
+			await expect
+				.poll(() => pageB.evaluate(() => window.location.hash), {
+					timeout: 15_000,
+				})
+				.not.toMatch(/^#\/invite\//);
 
 			await openAccountSettings(pageB);
 			await expect(pageB.getByText(accountFromA)).toBeVisible({
@@ -224,7 +225,6 @@ test.describe("passkey cross-context sync", () => {
 			).toHaveCount(0);
 			await pageB.getByTestId("encryptionPassphrase").fill(E2E_PASSPHRASE);
 			await pageB.getByRole("button", { name: "Unlock" }).click();
-			await dismissLandingTour(pageB);
 
 			await openAccountSettings(pageB);
 			await expect(pageB.getByText(accountFromA)).toBeVisible({
@@ -313,7 +313,6 @@ test.describe("vault membership management", () => {
 			});
 			await pageB.getByTestId("encryptionPassphrase").fill(E2E_PASSPHRASE);
 			await pageB.getByRole("button", { name: "Unlock" }).click();
-			await dismissLandingTour(pageB);
 
 			await openSyncSettings(pageA);
 			await expect(pageA.getByTestId("membersSection")).toBeVisible({
@@ -436,7 +435,6 @@ test.describe("vault membership management", () => {
 			});
 			await pageB.getByTestId("encryptionPassphrase").fill(E2E_PASSPHRASE);
 			await pageB.getByRole("button", { name: "Unlock" }).click();
-			await dismissLandingTour(pageB);
 
 			await openSyncSettings(pageA);
 			await expect(pageA.getByTestId(`member-row-${emailB}`)).toBeVisible({

--- a/playwright/tests/transactions.spec.ts
+++ b/playwright/tests/transactions.spec.ts
@@ -12,7 +12,6 @@ import {
 	setDateField,
 	test,
 	updateOnAccountTransactions,
-	updateOnAllTransactions,
 } from "../helpers";
 import {
 	defaultTransactionAccounts,
@@ -115,39 +114,40 @@ test("Transactions — create on MoneeeyCard, verify views, and edit-date reorde
 });
 
 test("Transactions — delete, inspect, and restore transactions from trash", async ({
-	transactionsPage: page,
+	seededPage: page,
 }) => {
-	await page.getByText("BRL MoneeeyCard").click();
-	await updateOnAccountTransactions(page, 6, "Groceries", "-42", "trash me");
+	await seedTestEnvironment(page, {
+		accounts: [
+			...defaultTransactionAccounts,
+			{ id: "test-payee-groceries", name: "Groceries", kind: "PAYEE" },
+		],
+		transactions: [
+			...defaultTransactions,
+			{
+				id: "test-transaction-trash-me",
+				from: "MoneeeyCard",
+				to: "Groceries",
+				amount: 42,
+				memo: "trash me",
+			},
+			{
+				id: "test-transaction-multi-trash",
+				from: "Banco Moneeey",
+				to: "Bitcoinss",
+				fromValue: 250,
+				toValue: 0.005,
+				memo: "multi trash",
+			},
+		],
+	});
 
+	await page.getByText("BRL MoneeeyCard").click();
 	await page.getByTestId("transactionDelete").nth(6).click();
 	await expect(page.getByText("Trash (1)")).toBeVisible({ timeout: 15_000 });
-
-	await OpenMenuItem(page, "All transactions");
-	const newTransactionIndex =
-		(await page.getByTestId("editorMemo").count()) - 1;
-	await updateOnAllTransactions(
-		page,
-		newTransactionIndex,
-		"Banco Moneeey",
-		"Bitcoinss",
-		undefined,
-		undefined,
-		"multi trash",
-	);
 
 	await clickMenuByTestId(page, SETTINGS_MENU_TESTID);
 	await page.getByTestId("tableDensitySwitcher_compact").click();
 	await OpenMenuItem(page, "All transactions");
-
-	await Input(page, "editorFrom_amount", undefined, newTransactionIndex).change(
-		"250",
-		"250",
-	);
-	await Input(page, "editorTo_amount", undefined, newTransactionIndex).change(
-		"0,00500000",
-		"0,005",
-	);
 
 	await page
 		.getByTestId("transactionTable-compactRow")

--- a/playwright/tests/transactions.spec.ts
+++ b/playwright/tests/transactions.spec.ts
@@ -8,11 +8,16 @@ import {
 	clickMenuByTestId,
 	expect,
 	retrieveRowsData,
+	seedTestEnvironment,
 	setDateField,
 	test,
 	updateOnAccountTransactions,
 	updateOnAllTransactions,
 } from "../helpers";
+import {
+	defaultTransactionAccounts,
+	defaultTransactions,
+} from "../helpers/wizard";
 
 const SETTINGS_MENU_TESTID = "appMenu_subitems_settings_settings_general";
 
@@ -110,12 +115,12 @@ test("Transactions — create on MoneeeyCard, verify views, and edit-date reorde
 });
 
 test("Transactions — delete, inspect, and restore transactions from trash", async ({
-	wizardPage: page,
+	transactionsPage: page,
 }) => {
 	await page.getByText("BRL MoneeeyCard").click();
-	await updateOnAccountTransactions(page, 1, "Groceries", "-42", "trash me");
+	await updateOnAccountTransactions(page, 6, "Groceries", "-42", "trash me");
 
-	await page.getByTestId("transactionDelete").nth(1).click();
+	await page.getByTestId("transactionDelete").nth(6).click();
 	await expect(page.getByText("Trash (1)")).toBeVisible({ timeout: 15_000 });
 
 	await OpenMenuItem(page, "All transactions");
@@ -195,27 +200,17 @@ test("Transactions — delete, inspect, and restore transactions from trash", as
 });
 
 test("Transactions — swapping direction flips from/to accounts", async ({
-	wizardPage: page,
+	seededPage: page,
 }) => {
+	await seedTestEnvironment(page, {
+		accounts: defaultTransactionAccounts,
+		transactions: [
+			{ ...defaultTransactions[0], memo: "Salary" },
+			defaultTransactions[1],
+			{ ...defaultTransactions[2], amount: 128.12, memo: "Dinner" },
+		],
+	});
 	await page.getByText("BRL MoneeeyCard").click();
-
-	// Add initial transactions
-	await updateOnAccountTransactions(
-		page,
-		1,
-		"Banco Moneeey",
-		"3000",
-		"Salary",
-		"3.000",
-	);
-	await updateOnAccountTransactions(page, 2, "Bakery123", "-60", "pao");
-	await updateOnAccountTransactions(
-		page,
-		3,
-		"Ristorant88",
-		"-128,12",
-		"Dinner",
-	);
 
 	// Wait for running balance to be updated
 	await Input(page, "editorRunning", undefined, 3).toHaveValue("4.811,88");


### PR DESCRIPTION
## Summary
- add a dev-only frontend E2E seed hook that creates encrypted app state directly
- use seeded Playwright fixtures for setup-heavy tests while keeping real transaction-entry coverage
- add frontend Jest coverage and Chromium Playwright JS coverage export scripts/artifacts

## Verification
- yarn ci
- cd frontend && yarn lint
- cd frontend && yarn test --runInBand
- cd playwright && ./node_modules/.bin/playwright test --reporter=list
- cd playwright && 100/100 full Playwright runs passed