### PR TITLE
chore(frontend): update react-window

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,7 +35,7 @@
 		"react-router-dom": "6.27.0",
 		"react-select": "5.10.2",
 		"react-virtualized-auto-sizer": "^1.0.26",
-		"react-window": "^1.8.11",
+		"react-window": "2.2.7",
 		"workbox-window": "^7.4.1"
 	},
 	"devDependencies": {
@@ -43,7 +43,7 @@
 		"@types/lodash": "4.17.20",
 		"@types/react": "18.3.1",
 		"@types/react-dom": "18.3.1",
-		"@types/react-window": "^1.8.8",
+		"@types/react-window": "2.0.0",
 		"@vitejs/plugin-react": "5.2.0",
 		"fake-indexeddb": "^6.2.5",
 		"jest": "29.7.0",

--- a/frontend/src/components/VirtualTableEditor.tsx
+++ b/frontend/src/components/VirtualTableEditor.tsx
@@ -1,6 +1,6 @@
 import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/24/outline";
 import {
-	type ComponentType,
+	type CSSProperties,
 	type Dispatch,
 	type KeyboardEvent,
 	type Ref,
@@ -12,10 +12,11 @@ import {
 } from "react";
 import AutoSizer from "react-virtualized-auto-sizer";
 import {
-	type FixedSizeListProps,
-	FixedSizeList as GenericFixedSizeList,
-	VariableSizeGrid as GenericVirtualizedGrid,
-	type VariableSizeGridProps,
+	type CellComponentProps,
+	List as FixedSizeList,
+	type GridImperativeAPI,
+	type RowComponentProps,
+	Grid as VirtualizedGrid,
 } from "react-window";
 
 import { observer } from "mobx-react-lite";
@@ -26,13 +27,8 @@ import Icon from "./base/Icon";
 import { Input } from "./base/Input";
 import { FieldVisibility } from "./editor/FieldDef";
 
-const VirtualizedGrid =
-	GenericVirtualizedGrid as unknown as ComponentType<VariableSizeGridProps>;
-
-const FixedSizeList =
-	GenericFixedSizeList as unknown as ComponentType<FixedSizeListProps>;
-
 const SCROLLBAR_WIDTH = 24;
+const OVERSCAN_ROW_COUNT = 10;
 // Fallback until the first DOM measurement resolves.
 const ROW_LINE_HEIGHT_FALLBACK = 24;
 const COMPACT_HEADER_VERTICAL_PADDING = 8;
@@ -86,10 +82,38 @@ type GridRenderCell = {
 	rowIndex: number;
 	column: ColumnDef;
 	row: Row;
-	style: object;
+	style: CSSProperties;
 	setSort: Dispatch<SetStateAction<SortColumn>>;
 	sort: SortColumn;
 };
+
+type VirtualGridCellProps = {
+	rows: Row[];
+	columns: ColumnDef[];
+	setSort: Dispatch<SetStateAction<SortColumn>>;
+	sort: SortColumn;
+	RenderCell: (props: GridRenderCell) => JSX.Element;
+};
+
+const VirtualGridCell = ({
+	columnIndex,
+	rowIndex,
+	style,
+	rows,
+	columns,
+	sort,
+	setSort,
+	RenderCell,
+}: CellComponentProps<VirtualGridCellProps>) => (
+	<RenderCell
+		style={style}
+		column={columns[columnIndex]}
+		rowIndex={rowIndex}
+		row={rows[rowIndex]}
+		sort={sort}
+		setSort={setSort}
+	/>
+);
 
 const SortIcon = ({ order }: { order?: "descend" | "ascend" }) => {
 	if (order === "ascend") {
@@ -157,13 +181,8 @@ const SortableHeaderText = ({
 	);
 };
 
-type ScrollData = {
-	scrollLeft: number;
-	scrollTop: number;
-};
-
 const VirtualGrid = ({
-	outerRef,
+	gridRef,
 	className,
 	gridHeight,
 	rowHeight,
@@ -172,48 +191,31 @@ const VirtualGrid = ({
 	columns,
 	sort,
 	setSort,
-	setScroll,
 	RenderCell,
 }: {
-	outerRef?: Ref<HTMLDivElement>;
+	gridRef?: Ref<GridImperativeAPI>;
 	className: string;
 	gridHeight: number;
 	rowHeight: number;
 	width: number;
 	rows: Row[];
 	columns: ColumnDef[];
-	setScroll?: (scrollData: ScrollData) => void;
 	setSort: Dispatch<SetStateAction<SortColumn>>;
 	sort: SortColumn;
 	RenderCell: (props: GridRenderCell) => JSX.Element;
 }) => (
 	<VirtualizedGrid
 		className={className}
-		height={gridHeight}
-		width={width}
+		style={{ height: gridHeight, width }}
 		rowCount={rows.length}
 		columnCount={columns.length}
-		rowHeight={() => rowHeight}
+		rowHeight={rowHeight}
 		columnWidth={(index: number) => columns[index].width}
-		outerRef={outerRef}
-		onScroll={({ scrollLeft, scrollTop }) =>
-			setScroll?.({ scrollLeft, scrollTop })
-		}
-		itemKey={({ columnIndex, rowIndex }) =>
-			`${rows[rowIndex]?.entityId ?? rowIndex}-${columnIndex}`
-		}
-	>
-		{({ columnIndex, rowIndex, style }) => (
-			<RenderCell
-				style={style}
-				column={columns[columnIndex]}
-				rowIndex={rowIndex}
-				row={rows[rowIndex]}
-				sort={sort}
-				setSort={setSort}
-			/>
-		)}
-	</VirtualizedGrid>
+		gridRef={gridRef}
+		overscanCount={OVERSCAN_ROW_COUNT}
+		cellComponent={VirtualGridCell}
+		cellProps={{ rows, columns, sort, setSort, RenderCell }}
+	/>
 );
 
 const HeaderCell = ({ column, style, sort, setSort }: GridRenderCell) => (
@@ -272,7 +274,8 @@ const VirtualTableGrid = ({
 	setSort: Dispatch<SetStateAction<SortColumn>>;
 	sort: SortColumn;
 } & WithDataTestId) => {
-	const headerRef = useRef<HTMLDivElement>(null);
+	const headerRef = useRef<GridImperativeAPI | null>(null);
+	const bodyRef = useRef<GridImperativeAPI | null>(null);
 	const calculatedColumns = useMemo(() => {
 		const totalWidth = columns.reduce((total, cur) => total + cur.width, 0);
 
@@ -292,12 +295,24 @@ const VirtualTableGrid = ({
 		columns: calculatedColumns,
 	};
 
+	useLayoutEffect(() => {
+		const body = bodyRef.current?.element;
+		const header = headerRef.current?.element;
+		if (!body || !header) return;
+
+		const syncHeaderScroll = () => {
+			header.scrollLeft = body.scrollLeft;
+		};
+		body.addEventListener("scroll", syncHeaderScroll, { passive: true });
+		return () => body.removeEventListener("scroll", syncHeaderScroll);
+	}, []);
+
 	return (
 		<>
 			<VirtualGrid
 				className={`!overflow-hidden bg-background-700 px-2 ${testId}-header`}
 				gridHeight={rowHeight}
-				outerRef={headerRef}
+				gridRef={headerRef}
 				{...common}
 				rows={[{ entityId: "Header" }]}
 				RenderCell={HeaderCell}
@@ -305,10 +320,8 @@ const VirtualTableGrid = ({
 			<VirtualGrid
 				className={`bg-background-800 px-2 pb-2 ${testId}-body`}
 				gridHeight={height - rowHeight}
+				gridRef={bodyRef}
 				{...common}
-				setScroll={({ scrollLeft }) => {
-					headerRef?.current?.scrollTo(scrollLeft, 0);
-				}}
 				rows={rows}
 				RenderCell={ContentCell}
 			/>
@@ -377,23 +390,21 @@ const CompactRowLine = ({
 
 const CompactContentCell = observer(
 	({
-		row,
-		rowIndex,
+		index,
 		style,
+		rows,
 		compactLayout,
 		columnsByTitle,
 		testId,
-	}: {
-		row: Row | undefined;
-		rowIndex: number;
-		style: object;
+	}: RowComponentProps<{
+		rows: Row[];
 		compactLayout: CompactLayout;
 		columnsByTitle: Map<string, ColumnDef>;
 		testId?: string;
-	}) => {
+	}>) => {
+		const row = rows[index];
 		if (!row) return <div style={style} />;
-		const bgColor =
-			rowIndex % 2 === 0 ? "bg-background-800" : "bg-background-600";
+		const bgColor = index % 2 === 0 ? "bg-background-800" : "bg-background-600";
 		return (
 			<div
 				style={style}
@@ -405,7 +416,7 @@ const CompactContentCell = observer(
 						key={`line_${lineIdx}_${row.entityId}`}
 						line={line}
 						row={row}
-						rowIndex={rowIndex}
+						rowIndex={index}
 						columnsByTitle={columnsByTitle}
 						testId={testId}
 					/>
@@ -550,23 +561,13 @@ const CompactVirtualTableGrid = ({
 			</div>
 			<FixedSizeList
 				className={`bg-background-800 pb-2 ${testId}-body`}
-				height={height - headerHeight}
-				width={width}
-				itemCount={rows.length}
-				itemSize={rowHeight}
-				itemKey={(index) => rows[index]?.entityId ?? String(index)}
-			>
-				{({ index, style }) => (
-					<CompactContentCell
-						row={rows[index]}
-						rowIndex={index}
-						style={style}
-						compactLayout={compactLayout}
-						columnsByTitle={columnsByTitle}
-						testId={testId}
-					/>
-				)}
-			</FixedSizeList>
+				style={{ height: height - headerHeight, width }}
+				rowCount={rows.length}
+				rowHeight={rowHeight}
+				overscanCount={OVERSCAN_ROW_COUNT}
+				rowComponent={CompactContentCell}
+				rowProps={{ rows, compactLayout, columnsByTitle, testId }}
+			/>
 		</>
 	);
 };

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -963,7 +963,7 @@
     "@babel/types" "^7.4.4"
     esutils "^2.0.2"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.18.3", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
+"@babel/runtime@^7.11.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.5", "@babel/runtime@^7.18.3", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
   version "7.27.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.27.0.tgz#fbee7cf97c709518ecc1f590984481d5460d4762"
   integrity sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==
@@ -2240,12 +2240,12 @@
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.12.tgz#b5d76568485b02a307238270bfe96cb51ee2a044"
   integrity sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==
 
-"@types/react-window@^1.8.8":
-  version "1.8.8"
-  resolved "https://registry.yarnpkg.com/@types/react-window/-/react-window-1.8.8.tgz#c20645414d142364fbe735818e1c1e0a145696e3"
-  integrity sha512-8Ls660bHR1AUA2kuRvVG9D/4XpRC6wjAaPT9dil7Ckc76eP9TKWZwwmgfq8Q1LANX3QNDnoU4Zp48A3w+zK69Q==
+"@types/react-window@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/react-window/-/react-window-2.0.0.tgz#9fe45015d6f98ec98a069362518c855fcc1fa8d0"
+  integrity sha512-E8hMDtImEpMk1SjswSvqoSmYvk7GEtyVaTa/GJV++FdDNuMVVEzpAClyJ0nqeKYBrMkGiyH6M1+rPLM0Nu1exQ==
   dependencies:
-    "@types/react" "*"
+    react-window "*"
 
 "@types/react@*":
   version "19.1.1"
@@ -4502,11 +4502,6 @@ math-intrinsics@^1.1.0:
   resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
   integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
 
-"memoize-one@>=3.1.1 <6":
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
-  integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
-
 memoize-one@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-6.0.0.tgz#b2591b871ed82948aee4727dc6abceeeac8c1045"
@@ -5007,13 +5002,10 @@ react-virtualized-auto-sizer@^1.0.26:
   resolved "https://registry.yarnpkg.com/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.26.tgz#e9470ef6a778dc4f1d5fd76305fa2d8b610c357a"
   integrity sha512-CblNyiNVw2o+hsa5/49NH2ogGxZ+t+3aweRvNSq7TVjDIlwk7ir4lencEg5HxHeSzwNarSkNkiu0qJSOXtxm5A==
 
-react-window@^1.8.11:
-  version "1.8.11"
-  resolved "https://registry.yarnpkg.com/react-window/-/react-window-1.8.11.tgz#a857b48fa85bd77042d59cc460964ff2e0648525"
-  integrity sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==
-  dependencies:
-    "@babel/runtime" "^7.0.0"
-    memoize-one ">=3.1.1 <6"
+react-window@*, react-window@2.2.7:
+  version "2.2.7"
+  resolved "https://registry.yarnpkg.com/react-window/-/react-window-2.2.7.tgz#7f3d31695d4323701b7e80dfc9bbbe1d4a0c160f"
+  integrity sha512-SH5nvfUQwGHYyriDUAOt7wfPsfG9Qxd6OdzQxl5oQ4dsSsUicqQvjV7dR+NqZ4coY0fUn3w1jnC5PwzIUWEg5w==
 
 react@18.3.1:
   version "18.3.1"

--- a/playwright/tests/compact-density.spec.ts
+++ b/playwright/tests/compact-density.spec.ts
@@ -1,3 +1,4 @@
+import { formatDate } from "../../frontend/src/utils/Date";
 import {
 	BudgetRow,
 	Input,
@@ -24,7 +25,7 @@ async function setDensity(
 test("Compact density — persistence, active ring, and table structure across views", async ({
 	wizardPage: page,
 }) => {
-	const today = new Date().toISOString().slice(0, 10);
+	const today = formatDate(new Date());
 
 	await test.step("picking compact persists and shows active ring, and round-trips to full", async () => {
 		await setDensity(page, "compact");

--- a/playwright/tests/virtual-table.spec.ts
+++ b/playwright/tests/virtual-table.spec.ts
@@ -1,0 +1,87 @@
+import type { Page } from "@playwright/test";
+import { formatDate } from "../../frontend/src/utils/Date";
+import {
+	OpenMenuItem,
+	clickMenuByTestId,
+	defaultSeedAccounts,
+	expect,
+	seedTestEnvironment,
+	test,
+} from "../helpers";
+
+const SETTINGS_MENU_TESTID = "appMenu_subitems_settings_settings_general";
+const VIRTUAL_ROW_COUNT = 120;
+
+const virtualTransactions = Array.from(
+	{ length: VIRTUAL_ROW_COUNT },
+	(_, i) => ({
+		id: `test-transaction-virtual-${String(i).padStart(3, "0")}`,
+		from: "MoneeeyCard",
+		to: "Virtual Payee",
+		amount: i + 1,
+		memo: `virtual-row-${String(i).padStart(3, "0")}`,
+		date: formatDate(new Date(2030, 0, i + 1)),
+	}),
+);
+
+async function renderedDesktopRowCount(page: Page) {
+	return await page.evaluate(() => {
+		const cells = document.querySelectorAll(
+			'.transactionTable-body [data-testid="rowCell"]',
+		);
+		return new Set(
+			Array.from(cells).map((cell) => cell.getAttribute("data-row-index")),
+		).size;
+	});
+}
+
+async function renderedCompactRowCount(page: Page) {
+	return await page.getByTestId("transactionTable-compactRow").count();
+}
+
+async function scrollTransactionTableToBottom(page: Page) {
+	await page.locator(".transactionTable-body").evaluate((element) => {
+		element.scrollTop = element.scrollHeight;
+		element.dispatchEvent(new Event("scroll", { bubbles: true }));
+	});
+}
+
+test("Virtual table renders a window of rows and scrolls to far transactions", async ({
+	seededPage: page,
+}) => {
+	await seedTestEnvironment(page, {
+		accounts: [
+			...defaultSeedAccounts,
+			{ id: "test-payee-virtual", name: "Virtual Payee", kind: "PAYEE" },
+		],
+		transactions: virtualTransactions,
+	});
+
+	await OpenMenuItem(page, "All transactions");
+	await expect(page.locator(".transactionTable-body")).toBeVisible();
+
+	await expect.poll(() => renderedDesktopRowCount(page)).toBeGreaterThan(0);
+	expect(await renderedDesktopRowCount(page)).toBeLessThan(VIRTUAL_ROW_COUNT);
+	await expect(
+		page.locator('input[data-testid="editorMemo"][value="virtual-row-000"]'),
+	).toBeVisible();
+
+	await scrollTransactionTableToBottom(page);
+	await expect(
+		page.locator('input[data-testid="editorMemo"][value="virtual-row-119"]'),
+	).toBeVisible({ timeout: 10_000 });
+	await expect(
+		page.locator('input[data-testid="editorMemo"][value="virtual-row-000"]'),
+	).toHaveCount(0);
+
+	await clickMenuByTestId(page, SETTINGS_MENU_TESTID);
+	await page.getByTestId("tableDensitySwitcher_compact").click();
+	await OpenMenuItem(page, "All transactions");
+	await expect.poll(() => renderedCompactRowCount(page)).toBeGreaterThan(0);
+	expect(await renderedCompactRowCount(page)).toBeLessThan(VIRTUAL_ROW_COUNT);
+
+	await scrollTransactionTableToBottom(page);
+	await expect(
+		page.locator('input[data-testid="editorMemo"][value="virtual-row-119"]'),
+	).toBeVisible({ timeout: 10_000 });
+});


### PR DESCRIPTION
## Summary
- add a Playwright baseline for virtual table scrolling in full and compact density
- update react-window to 2.2.7 and adapt VirtualTableEditor to the v2 Grid/List API
- keep explicit overscan so editable appended rows remain mounted during transaction-entry flows
- align compact-density date expectations with the app date formatter

## Verification
- yarn lint
- yarn ci
- cd frontend && yarn test --runInBand
- cd frontend && yarn build
- cd playwright && ./node_modules/.bin/playwright test tests/virtual-table.spec.ts tests/transactions.spec.ts tests/compact-density.spec.ts tests/budgets.spec.ts tests/accounts.spec.ts tests/dashboard.spec.ts --reporter=list